### PR TITLE
Updated Chiaotzu and Tien records to have TienMove instead of Move

### DIFF
--- a/src/records/challenges.md
+++ b/src/records/challenges.md
@@ -42,20 +42,20 @@ class Main {
 Make an instance of the `Tien` record and print it out.
 
 ```java,editable
-enum TienMove {
+enum Move {
     DODON_RAY,
     TRI_BEAM,
     EXPLODE
 }
 
 record Chiaotzu(
-    TienMove memorableMove
+    Move memorableMove
 ) {}
 
 record Tien(
     Chiaotzu onlyFriend,
-    TienMove firstMove,
-    TienMove secondMove
+    Move firstMove,
+    Move secondMove
 ) {}
 
 class Main {

--- a/src/records/challenges.md
+++ b/src/records/challenges.md
@@ -49,13 +49,13 @@ enum TienMove {
 }
 
 record Chiaotzu(
-    Move memorableMove
+    TienMove memorableMove
 ) {}
 
 record Tien(
     Chiaotzu onlyFriend,
-    Move firstMove,
-    Move secondMove
+    TienMove firstMove,
+    TienMove secondMove
 ) {}
 
 class Main {


### PR DESCRIPTION
Records challenge 2 was using what was likely an old enum name. Updated to `TienMove` instead of `Move`.